### PR TITLE
Export functions to create schemas instead of classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fuse",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "test": "jest",
     "test-watch": "jest --watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,8 @@ import Boolean from './models/schemas/booleanSchema'
 import Number from './models/schemas/numberSchema'
 import String from './models/schemas/stringSchema'
 
-export default { String, Number, Boolean }
+export default {
+  String: () => new String(),
+  Number: () => new Number(),
+  Boolean: () => new Boolean()
+}

--- a/test/models/schemas/boolean.test.ts
+++ b/test/models/schemas/boolean.test.ts
@@ -2,7 +2,7 @@ import f from '../../../src/index'
 import SchemaTestUtilities from '../schemaTestUtilities'
 
 describe('Boolean schema', () => {
-  const schema = new f.Boolean()
+  const schema = f.Boolean()
 
   describe('valid booleans', () => {
     test('true', () => expect(schema.validate(true).success).toBe(true))

--- a/test/models/schemas/number.test.ts
+++ b/test/models/schemas/number.test.ts
@@ -2,7 +2,7 @@ import f from '../../../src/index'
 import SchemaTestUtilities from '../schemaTestUtilities'
 
 describe('Number schema', () => {
-  const schema = new f.Number()
+  const schema = f.Number()
 
   describe('valid numbers', () => {
     test('one', () => expect(schema.validate(1).success).toBe(true))
@@ -33,7 +33,7 @@ describe('Number schema', () => {
 })
 
 describe('Integer number schema', () => {
-  const schema = new f.Number().int()
+  const schema = f.Number().int()
 
   describe('valid integers', () => {
     test('one', () => expect(schema.validate(1).success).toBe(true))

--- a/test/models/schemas/string.test.ts
+++ b/test/models/schemas/string.test.ts
@@ -2,7 +2,7 @@ import f from '../../../src/index'
 import SchemaTestUtilities from '../schemaTestUtilities'
 
 describe('String schema', () => {
-  const schema = new f.String()
+  const schema = f.String()
 
   describe('valid strings', () => {
     test('filled string', () => expect(schema.validate('Hello').success).toBe(true))
@@ -30,7 +30,7 @@ describe('String schema', () => {
 })
 
 describe('exact length string requirement', () => {
-  const schema = new f.String().length(10)
+  const schema = f.String().length(10)
 
   describe('correct length strings', () => {
     test('hello', () => expect(schema.validate('HelloWorld').success).toBe(true))


### PR DESCRIPTION
## Key Features

- Export functions to create instances of schema classes to make the user experience cleaner.
`const schema = new f.String()` is now `const schema = f.String()`

## Checklist:

- [ ] Bumped version number in package.json
- [ ] The code is easy to understand and commented in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
