### PR TITLE
Number parity (Even/Odd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ const maxSchema = f.Number().max(5) // Ensures the number is at most 5.
 const positiveSchema = f.Number().positive() // Ensures the number is positive.
 const negativeSchema = f.Number().negative() // Ensures the number is negative.
 
-/* A number schema can also be used to ensure the number is a certain type. */
+/* A number schema can also be used to ensure the integer has a certain parity. */
+/* Disclaimer: This requires the schema to have an integer check first! */
 const evenSchema = f.Number().even() // Ensures the number is even.
 const oddSchema = f.Number().odd() // Ensures the number is odd.
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fuse",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "scripts": {
     "build": "node build.js",
     "test": "jest",

--- a/src/models/requirements/number/numberParityRequirement.ts
+++ b/src/models/requirements/number/numberParityRequirement.ts
@@ -1,0 +1,64 @@
+import RequirementValidationResults from '../../../types/requirements/RequirementValidationResults'
+import Requirement from '../reqirement'
+
+export default class NumberParityRequirement extends Requirement {
+  private isEven: boolean = false
+  private isOdd: boolean = false
+
+  public setEven() {
+    if (this.isOdd) throw new Error('Cannot set even when odd is already set')
+
+    this.isEven = true
+  }
+
+  public setOdd() {
+    if (this.isEven) throw new Error('Cannot set odd when even is already set')
+
+    this.isOdd = true
+  }
+
+  public validate(value: number): RequirementValidationResults {
+    const results: RequirementValidationResults[] = []
+
+    results.push(this.validateEven(value))
+    results.push(this.validateOdd(value))
+
+    return this.combineRequirementValidationResults(results)
+  }
+
+  private validateEven(value: number): RequirementValidationResults {
+    if (this.isEven && !this.isValueEven(value)) {
+      return {
+        success: false,
+        errors: [
+          {
+            code: 'SIZE',
+            message: 'Value must be even'
+          }
+        ]
+      }
+    }
+
+    return { success: true }
+  }
+
+  private validateOdd(value: number): RequirementValidationResults {
+    if (this.isOdd && this.isValueEven(value)) {
+      return {
+        success: false,
+        errors: [
+          {
+            code: 'SIZE',
+            message: 'Value must be odd'
+          }
+        ]
+      }
+    }
+
+    return { success: true }
+  }
+
+  private isValueEven(value: number): boolean {
+    return value % 2 === 0
+  }
+}

--- a/src/models/schemas/numberSchema.ts
+++ b/src/models/schemas/numberSchema.ts
@@ -1,4 +1,5 @@
 import NumberIntegerRequirement from '../requirements/number/numberIntegerRequirement'
+import NumberParityRequirement from '../requirements/number/numberParityRequirement'
 import NumberRangeRequirement from '../requirements/number/numberRangeRequirement'
 import NumberRequirement from '../requirements/number/numberRequirement'
 import NumberSignRequirement from '../requirements/number/numberSignRequirement'
@@ -40,6 +41,24 @@ export default class Number extends Schema<number> {
   public negative(): Number {
     const numberSignRequirement = this.addRequirement(NumberSignRequirement)
     numberSignRequirement.setNegative()
+
+    return this
+  }
+
+  public even(): Number {
+    if (!this.hasRequirement(NumberIntegerRequirement)) throw new Error('Parity can only be set on integers')
+
+    const numberParityRequirement = this.addRequirement(NumberParityRequirement)
+    numberParityRequirement.setEven()
+
+    return this
+  }
+
+  public odd(): Number {
+    if (!this.hasRequirement(NumberIntegerRequirement)) throw new Error('Parity can only be set on integers')
+
+    const numberParityRequirement = this.addRequirement(NumberParityRequirement)
+    numberParityRequirement.setOdd()
 
     return this
   }

--- a/src/models/schemas/schema.ts
+++ b/src/models/schemas/schema.ts
@@ -44,6 +44,10 @@ export default abstract class Schema<T> {
     return requirement
   }
 
+  protected hasRequirement<T extends Requirement>(requirementClass: new () => T): boolean {
+    return this.requirements.some((requirement) => requirement instanceof requirementClass)
+  }
+
   private getSuccessValidationResults(value: T): SchemaValidationResults<T> {
     return { success: true, value }
   }

--- a/test/models/schemas/number.test.ts
+++ b/test/models/schemas/number.test.ts
@@ -129,3 +129,33 @@ describe('negative numbers', () => {
     })
   })
 })
+
+describe('number even parity', () => {
+  const schema = f.Number().int().even()
+
+  describe('valid even numbers', () => {
+    test('two', () => expect(schema.validate(2).success).toBe(true))
+  })
+
+  describe('invalid even numbers', () => {
+    test('one', () => {
+      const result = schema.validate(1)
+      expect(SchemaTestUtilities.checkSchemaResultErrorCodes(result, ['SIZE'])).toBe(true)
+    })
+  })
+})
+
+describe('number odd parity', () => {
+  const schema = f.Number().int().odd()
+
+  describe('valid odd numbers', () => {
+    test('one', () => expect(schema.validate(1).success).toBe(true))
+  })
+
+  describe('invalid odd numbers', () => {
+    test('two', () => {
+      const result = schema.validate(2)
+      expect(SchemaTestUtilities.checkSchemaResultErrorCodes(result, ['SIZE'])).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Key Features

- Allow for number schema to require an integer to be either even or odd.

## Checklist:

- [ ] Bumped version number according to [Semantic Versioning](https://semver.org/).
- [ ] The code is easy to understand and commented in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
